### PR TITLE
Feature base url as parameter

### DIFF
--- a/EasyTuya/TuyaAPI.py
+++ b/EasyTuya/TuyaAPI.py
@@ -10,8 +10,9 @@ class TuyaAPI:
         self.__accessKey = None
         self.__APIHeader = {'client_id': None, 'sign': None, 'sign_method': "HMAC-SHA256", 't': None}
         self.devices = {}
+        self.base_url = None
 
-    def __init__(self, id: str, secret: str):
+    def __init__(self, id: str, secret: str, base_url: str = "https://openapi.tuyaus.com"):
         """Initialize a connection with the Tuya API
 
         Args:
@@ -21,11 +22,12 @@ class TuyaAPI:
         self.clientID = id
         self.__accessKey = secret
         self.devices = {}
+        self.base_url = base_url.rstrip("/")  # use the url without trailing slashes
         try:
             t = str(time.time() * 1000)[:13]
             signature = HMAC.new(str.encode(self.__accessKey), str.encode(self.clientID + t), digestmod=SHA256).hexdigest().upper()
             self.__APIHeader = {'client_id': self.clientID, 'sign': signature, 'sign_method': "HMAC-SHA256", 't': t}
-            resp = r.get(url="https://openapi.tuyaus.com/v1.0/token?grant_type=1", headers=self.__APIHeader).json()
+            resp = r.get(url=self.base_url + "/v1.0/token?grant_type=1", headers=self.__APIHeader).json()
             self.tokenTimeLeft = resp['result']['expire_time']
             self.tokenGetTime = time.time()
             self.refreshToken = resp['result']['refresh_token']
@@ -53,7 +55,7 @@ class TuyaAPI:
             t = str(time.time() * 1000)[:13]
             signature = HMAC.new(str.encode(self.__accessKey), str.encode(self.clientID + t), digestmod=SHA256).hexdigest().upper()
             self.__APIHeader = {'client_id': self.clientID, 'sign': signature, 'sign_method': "HMAC-SHA256", 't': t}
-            refURL = "https://openapi.tuyaus.com/v1.0/token/" + self.refreshToken
+            refURL = self.base_url + "/v1.0/token/" + self.refreshToken
             resp = r.get(url=refURL, headers=self.__APIHeader, params=None).json()
             self.tokenTimeLeft = resp['result']['expire_time']
             self.tokenGetTime = time.time()
@@ -146,7 +148,7 @@ class TuyaAPI:
         if destIdentifier not in self.devices.keys():
             raise Exception("ERROR: Status destination identifier must correspond to a device or group of devices added with addDevice() or addDeviceGroup()")
         try:
-            statusURL = "https://openapi.tuyaus.com/v1.0/devices/[id]/status"
+            statusURL = self.base_url + "/v1.0/devices/[id]/status"
             if type(self.devices[destIdentifier]) != list:
                 thisURL = statusURL.replace('[id]', self.devices[destIdentifier].id)
                 resp = r.get(thisURL, headers=self.__APIHeader).json()

--- a/EasyTuya/TuyaAPI.py
+++ b/EasyTuya/TuyaAPI.py
@@ -18,6 +18,7 @@ class TuyaAPI:
         Args:
             id (str): Your Tuya developer account client id
             secret (str): Your Tuya developer account access secret
+            base_url (str, optional): The Tuya API base URL. Choose the right one for your location. The default is 'https://openapi.tuyaus.com'
         """
         self.clientID = id
         self.__accessKey = secret

--- a/EasyTuya/devices/Lights.py
+++ b/EasyTuya/devices/Lights.py
@@ -123,7 +123,7 @@ def sceneCommand(sceneNum = 4, bright = 255, freq = 191, hsvList = rainbowHSV):
 
 class Light:
 
-    def __init__(self, deviceID: str, deviceName: str):
+    def __init__(self, deviceID: str, deviceName: str, base_url: str = "https://openapi.tuyaus.com"):
         """Initialize a new light type device
 
         Args:
@@ -135,6 +135,7 @@ class Light:
         self.isOn = None
         self.workMode = None
         self.brightness = 0
+        self.base_url = base_url.rstrip("/")  # use the url without trailing slashes
 
     def toggleOnOff(self):
         """Generates the right on/off command based on current vals
@@ -157,7 +158,7 @@ class Light:
             Exception: Raises an exception on a failed call to Tuya API
         """
         try:
-            thisEnd = "https://openapi.tuyaus.com/v1.0/devices/[id]/commands".replace("[id]", self.id)
+            thisEnd = self.base_url + "/v1.0/devices/[id]/commands".replace("[id]", self.id)
             resp = r.post(url=thisEnd, headers=headerData, data=json.dumps(command))
             if resp.json()['success'] == False:
                 problem = "ERROR: Command failed, server response => " + json.dumps(resp.json())

--- a/EasyTuya/devices/Lights.py
+++ b/EasyTuya/devices/Lights.py
@@ -129,6 +129,7 @@ class Light:
         Args:
             deviceID (str): The ID of the device, found through the Tuya cloud development interface
             deviceName (str): The custom name you would like to give the light
+            base_url (str, optional): The Tuya API base URL. Choose the right one for your location. The default is 'https://openapi.tuyaus.com'
         """
         self.id = deviceID
         self.name = deviceName


### PR DESCRIPTION
The url is location based and therefore cannot be hard coded. With this change it can be passed as an optional parameter during object creation. Since the parameter is optional (default value is still the old url), it is not a breaking change.

For example, the base URL for Europe is "https://openapi.tuyaeu.com" instead of https://openapi.tuyaus.com